### PR TITLE
Update performance page in the docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,15 @@
 name = "HeterogeneousArrays"
 uuid = "40d36c5c-e028-4551-8108-c37812a952b9"
 version = "0.1.0"
-authors = ["Gregor Decristoforo <gregor.decristoforo@gmail.com>"]
+authors = ["Jakob Peder Pettersen <jakobpeder.pettersen@gmail.com>", "Gregor Decristoforo <gregor.decristoforo@gmail.com>", "Julia Mikhailova <julia.mikhailova@uit.no>"]
 
 [workspace]
 projects = ["docs"]
 
 [deps]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-BenchmarkTools = "1.6.3"
-RecursiveArrayTools = "3.48.0"
+RecursiveArrayTools = "3.49.0"
 Unitful = "1.28.0"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pkg> add HeterogeneousArrays
 
 Then use it in your code:
 ```julia
-using HeterogeneousArrays, Unitful, DifferentialEquations
+using HeterogeneousArrays
 ```
 
 ## Example: Pendulum Physics

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,7 +21,7 @@ pkg> add HeterogeneousArrays
 Then use it in your code:
 
 ```julia
-using HeterogeneousArrays, Unitful, DifferentialEquations
+using HeterogeneousArrays
 ```
 
 ## Basic Usage
@@ -79,20 +79,3 @@ sol = solve(prob, Vern8(), abstol = abstol_struct)
 While `HeterogeneousArrays.jl` is designed for SciML integration, it is not compatible with all solvers. It works seamlessly with explicit methods (e.g., `Tsit5()`, `Vern8()`) that rely on broadcasting. 
 However, implicit solvers (e.g., `Rosenbrock23()`) are currently unsupported because they require a homogeneous Jacobian matrix for linear algebra operations. 
 We are actively working on extending compatibility to stiff solvers in future releases.
-
-<!---
-## Citation
-If you use HeterogeneousArrays.jl in research, please cite:
-@article{SpeedyWeatherJOSS,
-  author = {Jacob Pettersen},
-  doi = {},
-  url = {https://doi.org/...},
-  title = {HeterogeneousArrays.jl ... },
-  year = {2026},
-  publisher = {},
-  volume = {},
-  number = {},
-  pages = {},
-  journal = {Journal of Open Source Software}
-}
--->

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,13 +1,13 @@
 # Welcome to HeterogeneousArrays
 
-HeterogeneousArrays is a Julia package for efficiently storing and operating on heterogeneous data. It introduces a type called HeterogeneousVector, a segmented array designed to hold elements of different concrete types while maintaining efficient, type-stable broadcasting.
+HeterogeneousArrays is a Julia package for efficiently storing and operating on heterogeneous data. It introduces a type called `HeterogeneousVector`, a segmented array designed to hold elements of different concrete types while maintaining efficient, type-stable broadcasting.
 
 ## Key Features
 
 * **Type-stable heterogeneous state**: Hold fields of different types in a single efficient container
 * **Unitful integration**: Enforce physical correctness at compile-time
 * **Zero-overhead broadcasting**: Fused broadcast operations maintain type stability
-* **ODE-friendly**: Drop-in compatible with SciML solvers (DifferentialEquations.jl)
+* **ODE-friendly**: Drop-in compatible with some SciML solvers (DifferentialEquations.jl)
 * **Physical safety**: Catch dimensional inconsistencies before they propagate
 
 ## Installation
@@ -43,7 +43,7 @@ v.v  # 5.2 s
 
 ## Example: Modeling a Pendulum
 
-HeterogeneousVector is ideal for physical systems where state variables have different units. It ensures that your numerical solver respects the underlying physics of your model.
+`HeterogeneousVector` is ideal for physical systems where state variables have different units. It ensures that your numerical solver respects the underlying physics of your model.
 
 We define a pendulum state with an angle θ (radians) and angular velocity ω (rad/s).
 
@@ -64,15 +64,19 @@ end
 params = (9.81u"m/s^2", 1.0u"m")
 tspan = (0.0u"s", 10.0u"s")
 prob = ODEProblem(pendulum_eom, u0, tspan, params)
-sol = DE.solve(prob, DE.Vern8())
+sol = solve(prob, Vern8())
 ```
 In SciML solvers (like `DifferentialEquations.jl`), you can provide tolerances. For heterogeneous data, your Absolute Error (`abstol`) must have the same units as your state fields.
 
 ```julia
 # Absolute tolerance must match the dimensions of u0
 abstol_struct = 1e-8 .* oneunit.(u0)
-sol = DE.solve(prob, DE.Vern8(), abstol = abstol_struct)
+sol = solve(prob, Vern8(), abstol = abstol_struct)
 ```
+
+## Compatibility with DifferentialEquations.jl
+
+While `HeterogeneousArrays.jl` is designed for SciML integration, it is not compatible with all solvers. It works seamlessly with explicit methods (e.g., `Tsit5()`, `Vern8()`) that rely on broadcasting. However, implicit solvers (e.g., `Rosenbrock23()`) are currently unsupported because they require a homogeneous Jacobian matrix for linear algebra operations. We are actively working on extending compatibility to stiff solvers in future releases.
 
 <!---
 ## Citation

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -81,7 +81,7 @@ the standard Julia tools for structured ODE states: `ArrayPartition` and `Compon
 ### The Benchmark
 We solve a standard 2-body Kepler problem (Orbital Mechanics) using the `Vern8()` solver. 
 This requires thousands of internal broadcast operations and unit conversions.
-The code used for this benchmark is available in the [`benchamrk/` directory](../../benchmark/runbenchmark.jl) of the repository.
+The code used for this benchmark is available in the [`benchamrk/` directory](https://github.com/yaccos/HeterogeneousArrays.jl/tree/main/benchmark/runbenchmark.jl) of the repository.
 
 All benchmark simulation were single-threaded on a CPU:
 ```Julia

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -81,6 +81,7 @@ the standard Julia tools for structured ODE states: `ArrayPartition` and `Compon
 ### The Benchmark
 We solve a standard 2-body Kepler problem (Orbital Mechanics) using the `Vern8()` solver. 
 This requires thousands of internal broadcast operations and unit conversions.
+The code used for this benchmark is available in the [`benchamrk/` directory](../../benchmark/runbenchmark.jl) of the repository.
 
 All benchmark simulation were single-threaded on a CPU:
 ```Julia

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -19,21 +19,28 @@ the compiler must generate conservative (slow) code for multiple possibilities.
 The compiler knows exactly what type is stored in each named field.
 
 ```julia
-v = HeterogeneousVector(x = [1.0, 2.0], y = 5.0)
-result = v.x[1] + v.y  # Fast: compiler knows x is Vector{Float64}, y is Float64
+v = HeterogeneousVector(x = [1.0u"m", 2.0u"m"], y = 5.0u"s")
+
+# Same physical quantity, different units (m + cm): type-stable and unit-safe
+sum_len = v.x[1] + 50.0u"cm"
+
+# Different components with different units: output unit is inferred at compile time (m*s)
+cross_term = v.x[1] * v.y
 ```
 
 ### Type-Stable: Broadcasting
 
 ```julia
-v = HeterogeneousVector(a = [1.0, 2.0], b = 3.0)
-w = HeterogeneousVector(a = [10.0, 20.0], b = 5.0)
-result = v .+ w  # Fast: Computed as (v.a .+ w.a) and (v.b .+ w.b)
+v = HeterogeneousVector(a = [1.0u"m", 2.0u"m"], b = 3.0u"s")
+w = HeterogeneousVector(a = [10.0u"m", 20.0u"m"], b = 5.0u"s")
+result = v .+ w  # Fast: computed field-wise as result.a = v.a .+ w.a and result.b = v.b .+ w.b
+result2 = v .* w  # Fast: computed field-wise as result2.a = v.a .* w.a and result2.b = v.b .* w.b
 ```
 
 ### Not Type-Stable: Flattened Indexing
 
-Using `v[i]` forces the compiler to check which field contains index i at runtime. This results in "type-shielding" or "boxing," which prevents optimization.
+Using `v[i]` forces a runtime check to determine which field contains index `i`.
+Because the accessed field is only known at runtime, this can introduce boxing and limit optimization.
 
 Benchmark Comparison:
 
@@ -92,16 +99,18 @@ Threads: 1 default, 1 interactive, 1 GC (on 20 virtual cores)
 ```
 
 
-| Implementation Strategy   |            Min (ms)   | StdErr (ms)   |   Allocs   |      Memory |
-|:------------------------|:--------------|:------------|:-------|:-------|
-|1. HeterogeneousVector (No Units)    |   0.0297    |     0.0015      |   803    |   40.9 KiB |
-|2. HeterogeneousVector (Units)        |  0.0295     |    0.0028    |     878   |    43.2 KiB |
-|3. ArrayPartition (No Units)           | 0.0347     |    0.0007    |     851   |    57.3 KiB |
-|4. ArrayPartition (Units)             |  1.0095     |    0.0328   |    11321   |   676.1 KiB |
-|5. ComponentVector (No Units)         |  0.0393    |     0.0003   |     1396   |    68.8 KiB |
-|6. ComponentVector (Units)            |  0.8537    |     0.0186   |    17745  |    359.9 KiB |
+| Implementation Strategy            |   Min (ms)   | StdErr (ms)   |   Allocs   |      Memory   |
+|:-----------------------------------|:-------------|:--------------|:-----------|:--------------|
+|1. HeterogeneousVector (No Units)   |   0.0297     |    0.0015     |     803    |    40.9 KiB   |
+|2. HeterogeneousVector (Units)      |   0.0295     |    0.0028     |     878    |    43.2 KiB   |
+|3. ArrayPartition (No Units)        |   0.0347     |    0.0007     |     851    |    57.3 KiB   |
+|4. ArrayPartition (Units)           |   1.0095     |    0.0328     |     11321  |    676.1 KiB  |
+|5. ComponentVector (No Units)       |   0.0393     |    0.0003     |     1396   |    68.8 KiB   |
+|6. ComponentVector (Units)          |   0.8537     |    0.0186     |     17745  |    359.9 KiB  |
 
 ### Analysis
-- **HeterogeneousVector** achieves performance parity with `ArrayPartition` while providing descriptive field names (`.r`, `.v`).
+- **HeterogeneousVector** consistently outperforms `ArrayPartition` in the 'Units'-enabled benchmark.
+- **HeterogeneousVector** achieves performance parity with `ArrayPartition` for the 'No Units' case while providing descriptive field names (`.r`, `.v`).
 - **Zero-Cost Units:** Thanks to specialized broadcasting kernels, using `Unitful` units results in near-zero performance overhead compared to raw numbers.
 - **Memory Efficiency:** The in-place mapping (via a specialized solver interface) ensures that we don't allocate unnecessary temporary arrays during the integration process.
+- **NB!** HeterogeneousVector provides substantial runtime performance benefits, however compilation times are longer.

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -113,5 +113,5 @@ Threads: 1 default, 1 interactive, 1 GC (on 20 virtual cores)
 - **`HeterogeneousVector`** consistently outperforms `ArrayPartition` in the 'Units'-enabled benchmark.
 - **`HeterogeneousVector`** achieves performance parity with `ArrayPartition` for the 'No Units' case while providing descriptive field names (`.r`, `.v`).
 - **Zero-Cost Units:** Thanks to specialized broadcasting kernels, using `Unitful` units results in near-zero performance overhead compared to raw numbers.
-- **Memory Efficiency:** The in-place mapping (via a specialized solver interface) ensures that we don't allocate unnecessary temporary arrays during the integration process.
-- **NB!** HeterogeneousVector provides substantial runtime performance benefits, however compilation times are longer.
+- **Memory Efficiency:** The in-place mapping (via a specialized solver interface) ensures that we don't allocate unnecessary temporary arrays during the integration process. 
+- **NB!** `HeterogeneousVector` provides substantial runtime performance benefits, however compilation times are longer. Hence, `ComponentVector` may in practice be faster for one-off simulations which only take a few seconds to run.

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -40,7 +40,7 @@ result2 = v .* w  # Fast: computed field-wise as result2.a = v.a .* w.a and resu
 ### Not Type-Stable: Flattened Indexing
 
 Using `v[i]` forces a runtime check to determine which field contains index `i`.
-Because the accessed field is only known at runtime, this can introduce boxing and limit optimization.
+Because the accessed field is only known at runtime, this can introduce type-instabilities and limit optimization.
 
 Benchmark Comparison:
 
@@ -109,8 +109,8 @@ Threads: 1 default, 1 interactive, 1 GC (on 20 virtual cores)
 |6. ComponentVector (Units)          |   0.8537     |    0.0186     |     17745  |    359.9 KiB  |
 
 ### Analysis
-- **HeterogeneousVector** consistently outperforms `ArrayPartition` in the 'Units'-enabled benchmark.
-- **HeterogeneousVector** achieves performance parity with `ArrayPartition` for the 'No Units' case while providing descriptive field names (`.r`, `.v`).
+- **`HeterogeneousVector`** consistently outperforms `ArrayPartition` in the 'Units'-enabled benchmark.
+- **`HeterogeneousVector`** achieves performance parity with `ArrayPartition` for the 'No Units' case while providing descriptive field names (`.r`, `.v`).
 - **Zero-Cost Units:** Thanks to specialized broadcasting kernels, using `Unitful` units results in near-zero performance overhead compared to raw numbers.
 - **Memory Efficiency:** The in-place mapping (via a specialized solver interface) ensures that we don't allocate unnecessary temporary arrays during the integration process.
 - **NB!** HeterogeneousVector provides substantial runtime performance benefits, however compilation times are longer.


### PR DESCRIPTION
This pull request updates the `docs/src/performance.md` documentation to improve clarity and provide more realistic examples involving physical units. The changes clarify the performance characteristics of `HeterogeneousVector` when used with unitful quantities, update code examples to use units, and revise the benchmark analysis to reflect new findings.

Code example improvements (Units):

* Updated code examples to use `Unitful` units (e.g., `1.0u"m"`, `5.0u"s"`), demonstrating type-stability and unit safety in arithmetic and broadcasting operations with `HeterogeneousVector`.

Documentation clarity:

* Clarified the explanation of type-stability and the effects of runtime field access, making it clear how boxing and optimization limitations can arise.
* Improved the description of field-wise broadcasting operations, including new examples for addition and multiplication.

Benchmark and analysis updates:

* Updated the benchmark table formatting for improved readability.
* Revised the analysis section to state that `HeterogeneousVector` outperforms `ArrayPartition` when using units and matches its performance without units, and added a note about longer compilation times. 

@yaccos Could you please check that the updated version sounds good?