### PR TITLE
Add TagBot GitHub Action

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,26 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        description: "[DEPRECATED] No longer has any effect"
+        default: "3"
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    # ubuntu-slim doesn't support containers, and thus won't work
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@cd42473a4fc34302627f0ece76783b591456d4a9 # v1.24.7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # For commits that modify workflow files: SSH key enables tagging, but
+          # releases require manual creation. For full automation of such commits,
+          # use a PAT with `workflow` scope instead of GITHUB_TOKEN.
+          # See: https://github.com/JuliaRegistries/TagBot#commits-that-modify-workflow-files
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}
+          # changelog_format: github  # 'custom' (default), 'github', or 'conventional'


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow file, `.github/workflows/TagBot.yml`, to automate tagging and release management using TagBot. The workflow is triggered on issue comments and manual dispatch, and is configured to use specific secrets for authentication.

**Automation and CI/CD improvements:**

* Added a new `TagBot` workflow to `.github/workflows/TagBot.yml` to automate tagging and release management, triggered by issue comments and manual dispatch events.
* Configured the workflow to use the `JuliaRegistries/TagBot` action with appropriate authentication tokens and SSH key for secure operations.
* Deprecated the `lookback` input, clarifying that it no longer has any effect.